### PR TITLE
Add prop-types to devDependencies, remove fusion-tokens from peer

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fusion-tokens": "^1.0.3",
     "nyc": "12.0.2",
     "prettier": "1.14.0",
+    "prop-types": "^15.6.0",
     "react": "^16.4.1",
     "react-dom": "^16.4.1",
     "regenerator-runtime": "^0.12.0",
@@ -60,8 +61,7 @@
     "unitest": "2.1.1"
   },
   "peerDependencies": {
-    "fusion-core": "^1.3.1",
-    "fusion-tokens": "^1.0.3"
+    "fusion-core": "^1.3.1"
   },
   "engines": {
     "node": ">= 8.9.0"


### PR DESCRIPTION
1) prop-types is a peer dep of fusion-react so we'll need it as a dev dep as well
2) Remove fusion-tokens from peer as none of its dependencies need it