### PR TITLE
Export HelmetProvider along with Helmet + Plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,10 @@
  * @flow
  */
 
-import Helmet from 'react-helmet-async';
+import {Helmet, HelmetProvider} from 'react-helmet-async';
 import serverPlugin from './server';
 import clientPlugin from './browser';
 
 declare var __NODE__: Boolean;
 export default (__NODE__ ? serverPlugin : clientPlugin);
-export {Helmet};
+export {Helmet, HelmetProvider};


### PR DESCRIPTION
In certain scenarios (such as unit testing), you might want to be able
to use a `<HelmetProvider />` without needing to set up a full fledged
fusion app instance and using the plugin.

In these cases, you currently need to add `react-helmet-async` as a
`dep/devDep` and make sure the version is not different from the one in
`fusion-plugin-react-helmet-async`.